### PR TITLE
Fix unrelated dispatches of messages

### DIFF
--- a/framework-module/src/main/java/io/axoniq/inspector/module/AxonInspectorConfigurerModule.kt
+++ b/framework-module/src/main/java/io/axoniq/inspector/module/AxonInspectorConfigurerModule.kt
@@ -127,7 +127,8 @@ class AxonInspectorConfigurerModule(
                 it.findModules(AggregateConfiguration::class.java).forEach { ac ->
                     val repo = ac.repository()
                     if (repo is EventSourcingRepository) {
-                        val field = ReflectionUtils.fieldsOf(repo::class.java).firstOrNull { f -> f.name == "eventStore" }
+                        val field =
+                            ReflectionUtils.fieldsOf(repo::class.java).firstOrNull { f -> f.name == "eventStore" }
                         if (field != null) {
                             val current = ReflectionUtils.getFieldValue<EventStore>(field, repo)
                             if (current !is InspectorWrappedEventStore) {

--- a/framework-module/src/main/java/io/axoniq/inspector/module/messaging/extensions.kt
+++ b/framework-module/src/main/java/io/axoniq/inspector/module/messaging/extensions.kt
@@ -51,27 +51,25 @@ fun Message<*>.toInformation() = MessageIdentifier(
 )
 
 fun UnitOfWork<*>.extractHandler(): HandlerStatisticsMetricIdentifier {
-    return resources().computeIfAbsent(INSPECTOR_HANDLER_INFORMATION) {
-        val processingGroup = resources()[INSPECTOR_PROCESSING_GROUP] as? String?
-        val isAggregate = message is CommandMessage<*> && isAggregateLifecycleActive()
-        val isProcessor = processingGroup != null
+    val processingGroup = resources()[INSPECTOR_PROCESSING_GROUP] as? String?
+    val isAggregate = message is CommandMessage<*> && isAggregateLifecycleActive()
+    val isProcessor = processingGroup != null
 
-        val component = when {
-            isAggregate -> (AggregateLifecycle.describeCurrentScope() as AggregateScopeDescriptor).type
-            isProcessor -> processingGroup
-            else -> resources()[INSPECTOR_DECLARING_CLASS] as String?
-        }
-        val type = when {
-            isAggregate -> HandlerType.Aggregate
-            isProcessor -> HandlerType.EventProcessor
-            else -> HandlerType.Message
-        }
-        HandlerStatisticsMetricIdentifier(
-            type = type,
-            component = component,
-            message = message.toInformation(),
-        )
-    } as HandlerStatisticsMetricIdentifier
+    val component = when {
+        isAggregate -> (AggregateLifecycle.describeCurrentScope() as AggregateScopeDescriptor).type
+        isProcessor -> processingGroup
+        else -> resources()[INSPECTOR_DECLARING_CLASS] as String?
+    }
+    val type = when {
+        isAggregate -> HandlerType.Aggregate
+        isProcessor -> HandlerType.EventProcessor
+        else -> HandlerType.Message
+    }
+    return HandlerStatisticsMetricIdentifier(
+        type = type,
+        component = component,
+        message = message.toInformation(),
+    )
 }
 
 fun isAggregateLifecycleActive(): Boolean {


### PR DESCRIPTION
When handling events in batch, dispatching of messages was possibly recorded on the wrong message. Messages were recorde on the afterCommit, at which point the handlerInformation of the unit of work had been set.

This PR removed caching of the handlerInformation and moves recording of dispatched messages to the span.