### PR TITLE
Remove maxBehind metric and add latency per segment

### DIFF
--- a/inspector-axon-api/src/main/java/io/axoniq/inspector/api/eventProcessorApi.kt
+++ b/inspector-axon-api/src/main/java/io/axoniq/inspector/api/eventProcessorApi.kt
@@ -37,9 +37,7 @@ data class ProcessorStatus(
     val error: Boolean,
     val segmentCapacity: Int,
     val activeSegments: Int,
-    val segmentCount: Int,
     val segments: List<SegmentStatus>,
-    val headPosition: Long,
     val ingestLatency: Double,
     val commitLatency: Double,
 )
@@ -57,7 +55,8 @@ data class SegmentStatus(
     val error: Boolean,
     val errorType: String?,
     val errorMessage: String?,
-    val position: Long,
+    val ingestLatency: Double?,
+    val commitLatency: Double?,
 )
 
 data class ProcessorSegmentId(

--- a/inspector-axon/src/main/java/io/axoniq/inspector/client/ServerProcessorReporter.kt
+++ b/inspector-axon/src/main/java/io/axoniq/inspector/client/ServerProcessorReporter.kt
@@ -45,7 +45,7 @@ class ServerProcessorReporter(
             try {
                 this.report()
             } catch (e: Exception) {
-                logger.error("Was unable to report processor metrics: {}", e.message)
+                logger.error("Was unable to report processor metrics: {}", e.message, e)
             }
         }, 1000, 1000, TimeUnit.MILLISECONDS)
     }

--- a/inspector-axon/src/main/java/io/axoniq/inspector/eventprocessor/metrics/InspectorHandlerProcessorInterceptor.kt
+++ b/inspector-axon/src/main/java/io/axoniq/inspector/eventprocessor/metrics/InspectorHandlerProcessorInterceptor.kt
@@ -40,13 +40,16 @@ class InspectorHandlerProcessorInterceptor(
         unitOfWork.resources()[INSPECTOR_PROCESSING_GROUP] = processorName
         val message = unitOfWork.message
         if (message is EventMessage) {
+            val segment = unitOfWork.resources()["Processor[$processorName]/SegmentId"] as? Int ?: -1
             processorMetricsRegistry.registerIngested(
                 processorName,
+                segment,
                 ChronoUnit.NANOS.between(message.timestamp, Instant.now())
             )
             unitOfWork.afterCommit {
                 processorMetricsRegistry.registerCommitted(
                     processorName,
+                    segment,
                     ChronoUnit.NANOS.between(message.timestamp, Instant.now())
                 )
             }


### PR DESCRIPTION
As discussed, the maxBehind metric does not make sense to monitor. Instead, the claimed percentage combined with latency should be monitored.

Because we think latency is important, latency is now sent for each segment