### PR TITLE
Detect decorated components and unwrap them

### DIFF
--- a/inspector-axon/src/main/java/io/axoniq/inspector/AxonInspectorConfigurerModule.kt
+++ b/inspector-axon/src/main/java/io/axoniq/inspector/AxonInspectorConfigurerModule.kt
@@ -32,12 +32,13 @@ import org.axonframework.config.Configurer
 import org.axonframework.config.ConfigurerModule
 import org.axonframework.eventsourcing.EventSourcingRepository
 import org.axonframework.eventsourcing.eventstore.EventStore
+import org.axonframework.modelling.command.Repository
 import org.axonframework.tracing.SpanFactory
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 
 class AxonInspectorConfigurerModule(
-    private val properties: io.axoniq.inspector.AxonInspectorProperties
+    private val properties: AxonInspectorProperties
 ) : ConfigurerModule {
 
     override fun configureModule(configurer: Configurer) {
@@ -122,10 +123,9 @@ class AxonInspectorConfigurerModule(
 
             it.onStart {
                 it.findModules(AggregateConfiguration::class.java).forEach { ac ->
-                    val repo = ac.repository()
+                    val repo = ac.repository().unwrapPossiblyDecoratedClass(Repository::class.java)
                     if (repo is EventSourcingRepository) {
-                        val field =
-                            ReflectionUtils.fieldsOf(repo::class.java).firstOrNull { f -> f.name == "eventStore" }
+                        val field = ReflectionUtils.fieldsOf(repo::class.java).firstOrNull { f -> f.name == "eventStore" }
                         if (field != null) {
                             val current = ReflectionUtils.getFieldValue<EventStore>(field, repo)
                             if (current !is InspectorWrappedEventStore) {

--- a/inspector-axon/src/main/java/io/axoniq/inspector/utils.kt
+++ b/inspector-axon/src/main/java/io/axoniq/inspector/utils.kt
@@ -1,0 +1,40 @@
+package io.axoniq.inspector
+
+import org.axonframework.common.ReflectionUtils
+import java.lang.reflect.Field
+import kotlin.reflect.KClass
+
+/*
+ * Copyright (c) 2022-2023. Inspector Axon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Find fields matching its own type. If found, it will unwrap the deeper value.
+ * Useful for when users wrap components as decorators, like Axon FireStarter does.
+ */
+fun <T : Any> T.unwrapPossiblyDecoratedClass(clazz: Class<out T>): T {
+    return fieldOfMatchingType(clazz)
+        ?.let { ReflectionUtils.getFieldValue(it, this) as T }
+        ?.unwrapPossiblyDecoratedClass(clazz)
+    // No field of provided type - reached end of decorator chain
+        ?: this
+}
+
+private fun <T : Any> T.fieldOfMatchingType(clazz: Class<out T>): Field? {
+    // When we reach our own AS-classes, stop unwrapping
+    if (this::class.java.name.startsWith("org.axonframework") && this::class.java.simpleName.startsWith("AxonServer")) return null
+    return ReflectionUtils.fieldsOf(this::class.java)
+        .firstOrNull { f -> f.type.isAssignableFrom(clazz) }
+}

--- a/inspector-axon/src/main/java/io/axoniq/inspector/utils.kt
+++ b/inspector-axon/src/main/java/io/axoniq/inspector/utils.kt
@@ -1,9 +1,3 @@
-package io.axoniq.inspector
-
-import org.axonframework.common.ReflectionUtils
-import java.lang.reflect.Field
-import kotlin.reflect.KClass
-
 /*
  * Copyright (c) 2022-2023. Inspector Axon
  *
@@ -19,6 +13,11 @@ import kotlin.reflect.KClass
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package io.axoniq.inspector
+
+import org.axonframework.common.ReflectionUtils
+import java.lang.reflect.Field
+import kotlin.reflect.KClass
 
 /**
  * Find fields matching its own type. If found, it will unwrap the deeper value.


### PR DESCRIPTION
When using Inspector Axon, and components are decorated, this leads to inaccurate information displayed in the UI. For example, when using FireStarter and Axon Server, the UI will show that the customer is not using Axon Server, because FireStartEventStore is not the AxonServerEventStore. By unwrapping it, we can show the correct information.

As a later feature we might consider showing the whole decoration chain.