### PR TITLE
Fix issue where configuration ordering caused problems for metrics.

### DIFF
--- a/inspector-axon-spring-boot-starter/src/main/java/io/axoniq/inspector/starter/AxonInspectorAutoConfiguration.kt
+++ b/inspector-axon-spring-boot-starter/src/main/java/io/axoniq/inspector/starter/AxonInspectorAutoConfiguration.kt
@@ -18,10 +18,7 @@ package io.axoniq.inspector.starter
 
 import io.axoniq.inspector.AxonInspectorConfigurerModule
 import io.axoniq.inspector.AxonInspectorProperties
-import io.axoniq.inspector.messaging.HandlerMetricsRegistry
-import io.axoniq.inspector.messaging.InspectorHandlerEnhancerDefinition
 import io.axoniq.inspector.messaging.InspectorSpanFactory
-import org.axonframework.config.Configuration
 import org.axonframework.config.ConfigurerModule
 import org.axonframework.tracing.MultiSpanFactory
 import org.axonframework.tracing.NoOpSpanFactory
@@ -77,12 +74,12 @@ class AxonInspectorAutoConfiguration {
 
     @Bean
     @ConditionalOnProperty("axon.inspector.credentials", matchIfMissing = false)
-    fun spanFactoryInspectorPostProcessor(configuration: Configuration) = object : BeanPostProcessor {
-        override fun postProcessBeforeInitialization(bean: Any, beanName: String): Any {
+    fun spanFactoryInspectorPostProcessor(): BeanPostProcessor = object : BeanPostProcessor {
+        override fun postProcessAfterInitialization(bean: Any, beanName: String): Any {
             if (bean !is SpanFactory || bean is InspectorSpanFactory) {
                 return bean
             }
-            val spanFactory = InspectorSpanFactory(configuration.getComponent(HandlerMetricsRegistry::class.java))
+            val spanFactory = InspectorSpanFactory()
             if (bean is NoOpSpanFactory) {
                 return spanFactory
             }

--- a/inspector-axon/src/main/java/io/axoniq/inspector/client/RSocketInspectorClient.kt
+++ b/inspector-axon/src/main/java/io/axoniq/inspector/client/RSocketInspectorClient.kt
@@ -53,6 +53,7 @@ class RSocketInspectorClient(
 
     override fun registerLifecycleHandlers(registry: Lifecycle.LifecycleRegistry) {
         registry.onStart(Phase.EXTERNAL_CONNECTIONS, this::start)
+        registry.onShutdown(Phase.EXTERNAL_CONNECTIONS, this::dispose)
     }
 
     fun send(route: String, payload: Any): Mono<Void> {

--- a/inspector-axon/src/main/java/io/axoniq/inspector/messaging/HandlerMetricsRegistry.kt
+++ b/inspector-axon/src/main/java/io/axoniq/inspector/messaging/HandlerMetricsRegistry.kt
@@ -44,7 +44,22 @@ class HandlerMetricsRegistry(
         lifecycle.onStart(Phase.INSTRUCTION_COMPONENTS, this::start)
     }
 
+    companion object {
+        private var instance: HandlerMetricsRegistry? = null
+        private var started: Boolean = false
+
+        /**
+         * Gets the current instance
+         */
+        fun getInstance() = instance
+    }
+
     fun start() {
+        if(instance != null) {
+            logger.debug("HandlerMetricRegistry instance already started. Skipping new.")
+            return
+        }
+        instance = this
         executor.scheduleAtFixedRate({
             try {
                 val stats = getStats()
@@ -54,6 +69,7 @@ class HandlerMetricsRegistry(
                 logger.warn("No metrics could be reported to Inspector Axon: {}", e.message)
             }
         }, 10, 10, TimeUnit.SECONDS)
+        started = true
     }
 
     private fun getStats(): StatisticReport {

--- a/inspector-axon/src/main/java/io/axoniq/inspector/messaging/InspectorSpanFactory.kt
+++ b/inspector-axon/src/main/java/io/axoniq/inspector/messaging/InspectorSpanFactory.kt
@@ -22,15 +22,12 @@ import org.axonframework.messaging.unitofwork.CurrentUnitOfWork
 import org.axonframework.tracing.Span
 import org.axonframework.tracing.SpanAttributesProvider
 import org.axonframework.tracing.SpanFactory
-import org.axonframework.tracing.SpanScope
 import org.slf4j.LoggerFactory
 import java.util.concurrent.ConcurrentHashMap
 import java.util.function.Supplier
 
 
-class InspectorSpanFactory(
-    private val registry: HandlerMetricsRegistry
-) : SpanFactory {
+class InspectorSpanFactory : SpanFactory {
     private val logger = LoggerFactory.getLogger(this::class.java)
 
     companion object {
@@ -108,7 +105,7 @@ class InspectorSpanFactory(
         private fun report(end: Long) {
             logger.trace("Reporting span for message id $messageId = $handlerMetricIdentifier")
             val success = handlerSuccessful && transactionSuccessful
-            registry.registerMessageHandled(
+            HandlerMetricsRegistry.getInstance()?.registerMessageHandled(
                 handler = handlerMetricIdentifier!!,
                 success = success,
                 duration = end - timeStarted!!,
@@ -116,7 +113,7 @@ class InspectorSpanFactory(
             )
             if(success) {
                 dispatchedMessages.forEach {
-                    registry.registerMessageDispatchedDuringHandling(
+                    HandlerMetricsRegistry.getInstance()?.registerMessageDispatchedDuringHandling(
                         DispatcherStatisticIdentifier(handlerMetricIdentifier, it)
                     )
                 }


### PR DESCRIPTION
Because the postprocessor depended on the entire Configuration object of Axon, it caused the MetricRegistry to initialize early. This in turn caused Spring Boot metrics to be missing from the metric registry.

The HandlerMetricsRegistry now sets a static instance upon start, which is picked up by the SpanFactory. This removed any dependency, causing normal initialization order again.

Fixes #33