### PR TITLE
Fix latency while batching is active, and remove latency from process…

### DIFF
--- a/inspector-axon-api/src/main/java/io/axoniq/inspector/api/eventProcessorApi.kt
+++ b/inspector-axon-api/src/main/java/io/axoniq/inspector/api/eventProcessorApi.kt
@@ -38,8 +38,6 @@ data class ProcessorStatus(
     val segmentCapacity: Int,
     val activeSegments: Int,
     val segments: List<SegmentStatus>,
-    val ingestLatency: Double,
-    val commitLatency: Double,
 )
 
 data class ProcessingGroupStatus(

--- a/inspector-axon/src/main/java/io/axoniq/inspector/eventprocessor/ProcessorReportCreator.kt
+++ b/inspector-axon/src/main/java/io/axoniq/inspector/eventprocessor/ProcessorReportCreator.kt
@@ -49,8 +49,6 @@ class ProcessorReportCreator(
                     sep.maxCapacity(),
                     sep.processingStatus().filterValues { !it.isErrorState }.size,
                     sep.processingStatus().map { (_, segment) -> segment.toStatus(entry.key) },
-                    metricsRegistry.ingestLatencyForProcessor(entry.key),
-                    metricsRegistry.commitLatencyForProcessor(entry.key),
                 )
             }
     )

--- a/inspector-axon/src/main/java/io/axoniq/inspector/eventprocessor/metrics/ProcessorMetricsRegistry.kt
+++ b/inspector-axon/src/main/java/io/axoniq/inspector/eventprocessor/metrics/ProcessorMetricsRegistry.kt
@@ -33,18 +33,8 @@ class ProcessorMetricsRegistry {
         commitLatencyForProcessor(processor, segment).setValue(latencyInNanos.toDouble() / 1000000)
     }
 
-    fun ingestLatencyForProcessor(processor: String): Double {
-        val map = ingestLatencyRegistry[processor] ?: return 0.0
-        return map.values.maxOf { it.getValue() }
-    }
-
     fun ingestLatencyForProcessor(processor: String, segment: Int): ExpiringLatencyValue {
         return ingestLatencyRegistry.computeIfAbsent(processor) { mutableMapOf() }.computeIfAbsent(segment) { ExpiringLatencyValue() }
-    }
-
-    fun commitLatencyForProcessor(processor: String): Double {
-        val map = commitLatencyRegistry[processor] ?: return 0.0
-        return map.values.maxOf { it.getValue() }
     }
 
     fun commitLatencyForProcessor(processor: String, segment: Int): ExpiringLatencyValue {


### PR DESCRIPTION
…or level.

This commit changes when the commit latency is registered. When batching, the latency was measured of the first event in the batch, due to the reverse callback order of the afterCommit hook. The afterCommit hook is now only set for the last message, so the latency of the last message in the batch is measured. This was only noticable during very few events and while replaying.

In addition the latencies were removed from the processor level of the report. These were unusable, because latency for unclaimed segments was kept. The IA server should take care of determining how to handle individual latency values of segments and aggregate them, not the client.