### PR TITLE
Fix rolling count to be more reliable measurement

### DIFF
--- a/inspector-axon/src/main/java/io/axoniq/inspector/messaging/HandlerMetricsRegistry.kt
+++ b/inspector-axon/src/main/java/io/axoniq/inspector/messaging/HandlerMetricsRegistry.kt
@@ -55,7 +55,7 @@ class HandlerMetricsRegistry(
     }
 
     fun start() {
-        if(instance != null) {
+        if (instance != null) {
             logger.debug("HandlerMetricRegistry instance already started. Skipping new.")
             return
         }
@@ -78,8 +78,8 @@ class HandlerMetricsRegistry(
                 .map {
                     HandlerStatisticsWithIdentifier(
                         it.key, HandlerStatistics(
-                            it.value.totalCount.value(),
-                            it.value.failureCount.value(),
+                            it.value.totalCount.count(),
+                            it.value.failureCount.count(),
                             it.value.totalTimer.takeSnapshot().toDistribution(),
                             it.value.metrics.map { (k, v) -> k.fullIdentifier to v.takeSnapshot().toDistribution() }
                                 .toMap()
@@ -90,15 +90,15 @@ class HandlerMetricsRegistry(
                 .map {
                     DispatcherStatisticsWithIdentifier(
                         it.key,
-                        DispatcherStatistics(it.value.value())
+                        DispatcherStatistics(it.value.count())
                     )
                 },
             aggregates = aggregates.entries
                 .map {
                     AggregateStatisticsWithIdentifier(
                         it.key, AggregateStatistics(
-                            it.value.totalCount.value(),
-                            it.value.failureCount.value(),
+                            it.value.totalCount.count(),
+                            it.value.failureCount.count(),
                             it.value.totalTimer.takeSnapshot().toDistribution(),
                             it.value.metrics.map { (k, v) -> k.fullIdentifier to v.takeSnapshot().toDistribution() }
                                 .toMap()
@@ -107,13 +107,13 @@ class HandlerMetricsRegistry(
                 })
 
         handlers.values.forEach {
-            it.totalCount.incrementWindow()
-            it.failureCount.incrementWindow()
+            it.totalCount.pruneData()
+            it.failureCount.pruneData()
         }
-        dispatches.values.forEach { it.incrementWindow() }
+        dispatches.values.forEach { it.pruneData() }
         aggregates.values.forEach {
-            it.totalCount.incrementWindow()
-            it.failureCount.incrementWindow()
+            it.totalCount.pruneData()
+            it.failureCount.pruneData()
         }
         return flow
     }


### PR DESCRIPTION
This PR fixes a predicament with the RollingCountMeasure, which often led to missing invocations of a message handler due to the way the values rotates. The variables have been replaced by a map, and counts are separated into buckets of 2.5 seconds. The value is calculated over the time in the last minute before the last 2.5 seconds began (as to not include incomplete buckets and provide inaccurate values).