### PR TITLE
Fix problem with SagaScopeDescriptor

### DIFF
--- a/inspector-axon-api/src/main/java/io/axoniq/inspector/api/eventProcessorApi.kt
+++ b/inspector-axon-api/src/main/java/io/axoniq/inspector/api/eventProcessorApi.kt
@@ -38,6 +38,10 @@ data class ProcessorStatus(
     val segmentCapacity: Int,
     val activeSegments: Int,
     val segments: List<SegmentStatus>,
+    @Deprecated(message = "Will be removed in 0.1.6+")
+    val ingestLatency: Double = 0.0,
+    @Deprecated(message = "Will be removed in 0.1.6+")
+    val commitLatency: Double = 0.0,
 )
 
 data class ProcessingGroupStatus(

--- a/inspector-axon/src/main/java/io/axoniq/inspector/api/InspectorMeasuringHandlerInterceptor.kt
+++ b/inspector-axon/src/main/java/io/axoniq/inspector/api/InspectorMeasuringHandlerInterceptor.kt
@@ -48,7 +48,7 @@ class InspectorMeasuringHandlerInterceptor(
         }
 
         val time = (endBefore!! - start) + (end - startAfter!!)
-        InspectorSpanFactory.onTopLevelSpanIfActive(unitOfWork.message) {
+        InspectorSpanFactory.onTopLevelSpanIfActive {
             val metric = UserHandlerInterceptorMetric(identifier = "mhi_$name")
             it.registerMetricValue(metric, time)
         }


### PR DESCRIPTION
If a command was dispatched on the local command bus by a saga, th saga scope would be active and a classcast exception could occur. This has been resolved by adding a type check. In addition, the entire method has been try-catched in order to prevent interruptions in the future.

Last but not least, some API properties were re-added as deprecated so the connector can be used by people before the new server is running.