### PR TITLE
Allow disabling of DLQ and add information about data sent to AxonIQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ within the framework.
 ![Screenshot of the handler performance screen](.github/img/screenshot_handler_performance.png)
 
 This repository contains the Open-Source connectors that your application will use through maven dependencies.
-For actual configuration, please consult the setup instructions that will be provided by Inspector Axon itself. 
+For actual configuration, please consult the setup instructions that will be provided by Inspector Axon itself.
 
 [You can visit Inspector Axon here.](https://inspector.axoniq.io)
 
@@ -19,3 +19,25 @@ Built with ❤ by the Axon Framework team
 ### application properties
 
 * `axon.inspector.enabled` - allows disabling the autoconfiguration via `axon.inspector.enabled=false`, default: `true`
+* `axon.inspector.dlq-enabled` - allows access to the messages in the DLQ, default: `true`
+
+## Data sent to AxonIQ
+
+Inspector Axon is an [AxonIQ](https://axoniq.io) SaaS product. Your application will periodically or upon request send
+information to the servers of AxonIQ. Please check our [legal documentation](https://inspector.axoniq.io/legal) for the
+measures we implemented to protect your data.
+
+The following data will be sent to the servers of AxonIQ:
+
+- Event processor information
+  - Name, latency, status, position
+  - Occurs every 2 seconds
+- Handler statistics
+  - Message names and names of handling components
+  - Statistics such as latency, throughput and error rates
+  - Correlation between messages and different handlers
+  - Occurs every 20 seconds
+- Dead Letter Information
+  - Contains message name, error information and event payload
+  - Occurs upon user request
+  - Can be disabled by 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The following data will be sent to the servers of AxonIQ:
   - Occurs every 2 seconds
 - Handler statistics
   - Message names and names of handling components
+  - Message payload, or ids, are not sent to AxonIQ servers
   - Statistics such as latency, throughput and error rates
   - Correlation between messages and different handlers
   - Occurs every 20 seconds
@@ -41,3 +42,6 @@ The following data will be sent to the servers of AxonIQ:
   - Contains message name, error information and event payload
   - Occurs upon user request
   - Can be disabled by 
+
+If you are concerned about the message data being sent to AxonIQ, please contact us at,
+disabling the DLQ functionality will prevent that in all cases.

--- a/inspector-axon-spring-boot-starter/src/main/java/io/axoniq/inspector/starter/InspectorProperties.kt
+++ b/inspector-axon-spring-boot-starter/src/main/java/io/axoniq/inspector/starter/InspectorProperties.kt
@@ -27,4 +27,5 @@ class InspectorProperties {
     var credentials: String? = null
     var initialDelay: Long = 0
     var applicationName: String? = null
+    var dlqEnabled: Boolean = false
 }

--- a/inspector-axon-spring-boot-starter/src/main/java/io/axoniq/inspector/starter/InspectorProperties.kt
+++ b/inspector-axon-spring-boot-starter/src/main/java/io/axoniq/inspector/starter/InspectorProperties.kt
@@ -27,5 +27,5 @@ class InspectorProperties {
     var credentials: String? = null
     var initialDelay: Long = 0
     var applicationName: String? = null
-    var dlqEnabled: Boolean = false
+    var dlqEnabled: Boolean = true
 }

--- a/inspector-axon/src/main/java/io/axoniq/inspector/AxonInspectorProperties.kt
+++ b/inspector-axon/src/main/java/io/axoniq/inspector/AxonInspectorProperties.kt
@@ -26,4 +26,5 @@ class AxonInspectorProperties(
     val secure: Boolean = true,
     val threadPoolSize: Int = 1,
     val initialDelay: Long = 0,
+    val dlqEnabled: Boolean = true,
 )


### PR DESCRIPTION
Several customers are asking for clarifying information about data being sent to AxonIQ, and are concerned about the possibility of retrieving DLQ data. This PR provides documentation and a method to disable responses for the DLQ.

Note that not enabling the DLQ will simply remove the route from the application. 