### PR TITLE
Add the CLAIM operation for event processors

### DIFF
--- a/inspector-axon-api/src/main/java/io/axoniq/inspector/api/Routes.kt
+++ b/inspector-axon-api/src/main/java/io/axoniq/inspector/api/Routes.kt
@@ -31,6 +31,7 @@ object Routes {
 
         const val STATUS = "event-processor-status"
         const val SEGMENTS = "event-processor-segments"
+        const val CLAIM = "event-processor-claim"
     }
 
     object ProcessingGroup {

--- a/inspector-axon/src/main/java/io/axoniq/inspector/AxonInspectorConfigurerModule.kt
+++ b/inspector-axon/src/main/java/io/axoniq/inspector/AxonInspectorConfigurerModule.kt
@@ -30,6 +30,7 @@ import io.axoniq.inspector.messaging.InspectorDispatchInterceptor
 import io.axoniq.inspector.messaging.InspectorSpanFactory
 import io.axoniq.inspector.messaging.InspectorWrappedEventStore
 import org.axonframework.common.ReflectionUtils
+import org.axonframework.common.transaction.TransactionManager
 import org.axonframework.config.AggregateConfiguration
 import org.axonframework.config.Configurer
 import org.axonframework.config.ConfigurerModule
@@ -61,7 +62,10 @@ class AxonInspectorConfigurerModule(
                 SetupPayloadCreator(it)
             }
             .registerComponent(EventProcessorManager::class.java) {
-                EventProcessorManager(it.eventProcessingConfiguration())
+                EventProcessorManager(
+                    it.eventProcessingConfiguration(),
+                    it.getComponent(TransactionManager::class.java)
+                )
             }
             .registerComponent(RSocketPayloadEncodingStrategy::class.java) {
                 CborEncodingStrategy()

--- a/inspector-axon/src/main/java/io/axoniq/inspector/eventprocessor/EventProcessorManager.kt
+++ b/inspector-axon/src/main/java/io/axoniq/inspector/eventprocessor/EventProcessorManager.kt
@@ -18,51 +18,95 @@ package io.axoniq.inspector.eventprocessor
 
 import io.axoniq.inspector.api.ResetDecision
 import io.axoniq.inspector.api.ResetDecisions
+import org.axonframework.common.ReflectionUtils
+import org.axonframework.common.transaction.TransactionManager
 import org.axonframework.config.EventProcessingConfiguration
-import org.axonframework.eventhandling.EventProcessor
 import org.axonframework.eventhandling.StreamingEventProcessor
+import org.axonframework.eventhandling.TrackingEventProcessor
+import org.axonframework.eventhandling.pooled.PooledStreamingEventProcessor
+import org.slf4j.LoggerFactory
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 
-class EventProcessorManager(private val eventProcessingConfig: EventProcessingConfiguration) {
+class EventProcessorManager(private val eventProcessingConfig: EventProcessingConfiguration,
+    private val transactionManager: TransactionManager) {
+    private val logger = LoggerFactory.getLogger(this::class.java)
 
     fun start(processorName: String) {
-        eventProcessingConfig.eventProcessor(processorName, EventProcessor::class.java)
-            .orElseThrow { IllegalArgumentException("Event Processor [$processorName] not found!") }
-            .start()
+        eventProcessor(processorName).start()
     }
 
     fun stop(processorName: String) {
-        eventProcessingConfig
-            .eventProcessor(processorName, EventProcessor::class.java)
-            .orElseThrow { IllegalArgumentException("Event Processor [$processorName] not found!") }
-            .shutDown()
+        eventProcessor(processorName).shutDown()
     }
 
     fun releaseSegment(processorName: String, segmentId: Int) {
-        eventProcessingConfig
-            .eventProcessor(processorName, StreamingEventProcessor::class.java)
-            .orElseThrow { IllegalArgumentException("Streaming Event Processor [$processorName] not found.") }
-            .releaseSegment(segmentId)
+        eventProcessor(processorName).releaseSegment(segmentId)
+    }
+
+    fun claimSegment(processorName: String, segmentId: Int): Boolean {
+        val processor = eventProcessor(processorName)
+        if (processor is TrackingEventProcessor) {
+            logger.info("You are load-balancing TrackingEventProcessor. This is very ineffective. Consider using PooledStreamingEventProcessor instead.")
+        } else if (processor is PooledStreamingEventProcessor) {
+            try {
+                val coordinatorField = processor::class.java.declaredFields.firstOrNull { it.name == "coordinator" }
+                    ?: throw IllegalStateException("Could not find Coordinator field!")
+                val coordinator = ReflectionUtils.getFieldValue<Any>(coordinatorField, processor)
+                val coordinationTaskField =
+                    coordinator::class.java.declaredFields.firstOrNull { it.name == "coordinationTask" }
+                        ?: throw IllegalStateException("Could not find CoordinationTask field!")
+                val coordinationTaskAtomicReference = ReflectionUtils
+                    .getFieldValue<AtomicReference<*>>(
+                        coordinationTaskField,
+                        coordinator
+                    )
+                val coordinationTask = coordinationTaskAtomicReference.get()
+                val unclaimedSegmentValidationThresholdField =
+                    coordinationTask::class.java.declaredFields.firstOrNull { it.name == "unclaimedSegmentValidationThreshold" }
+                        ?: throw IllegalStateException("Could not find unclaimedSegmentValidationThreshold field!")
+                ReflectionUtils.setFieldValue(unclaimedSegmentValidationThresholdField, coordinationTask, 0L)
+
+                val taskMethod = coordinationTask::class.java.declaredMethods.firstOrNull { it.name == "scheduleImmediateCoordinationTask" }
+                    ?: throw IllegalStateException("Could not find scheduleImmediateCoordinationTask method!")
+                ReflectionUtils.ensureAccessible(taskMethod)
+                taskMethod.invoke(coordinationTask)
+
+            } catch (e: Exception) {
+                logger.warn("Was unable to wait for segment CLAIM command due to internal error", e)
+                return false
+            }
+        }
+
+        // Wait until claimed
+        var loop = 0
+        while (loop < 300) {
+            Thread.sleep(100)
+            if (processor.processingStatus().containsKey(segmentId)) {
+                logger.info("Processor [$processorName] successfully claimed segment [$segmentId] in approx. [${loop * 100}ms].")
+                return true
+            }
+            loop++
+        }
+
+        logger.info("Processor [$processorName] failed to claim [$segmentId] in approx. [${loop * 100}ms].")
+
+
+        return false
     }
 
     fun splitSegment(processorName: String, segmentId: Int) =
-        eventProcessingConfig
-            .eventProcessor(processorName, StreamingEventProcessor::class.java)
-            .orElseThrow { IllegalArgumentException("Streaming Event Processor [$processorName] not found.") }
+        eventProcessor(processorName)
             .splitSegment(segmentId)
             .get(5, TimeUnit.SECONDS)
 
     fun mergeSegment(processorName: String, segmentId: Int) =
-        eventProcessingConfig
-            .eventProcessor(processorName, StreamingEventProcessor::class.java)
-            .orElseThrow { IllegalArgumentException("Streaming Event Processor [$processorName] not found.") }
+        eventProcessor(processorName)
             .mergeSegment(segmentId)
             .get(5, TimeUnit.SECONDS)
 
     fun resetTokens(resetDecision: ResetDecision) =
-        eventProcessingConfig
-            .eventProcessor(resetDecision.processorName, StreamingEventProcessor::class.java)
-            .orElseThrow { IllegalArgumentException("Streaming Event Processor [${resetDecision.processorName}] not found.") }
+        eventProcessor(resetDecision.processorName)
             .resetTokens { messageSource ->
                 when (resetDecision.decision) {
                     ResetDecisions.HEAD -> messageSource.createHeadToken()
@@ -71,4 +115,8 @@ class EventProcessorManager(private val eventProcessingConfig: EventProcessingCo
                 }
             }
 
+
+    private fun eventProcessor(processorName: String): StreamingEventProcessor =
+        eventProcessingConfig.eventProcessor(processorName, StreamingEventProcessor::class.java)
+            .orElseThrow { IllegalArgumentException("Event Processor [$processorName] not found!") }
 }

--- a/inspector-axon/src/main/java/io/axoniq/inspector/eventprocessor/ProcessorReportCreator.kt
+++ b/inspector-axon/src/main/java/io/axoniq/inspector/eventprocessor/ProcessorReportCreator.kt
@@ -20,6 +20,7 @@ import io.axoniq.inspector.api.*
 import io.axoniq.inspector.eventprocessor.metrics.ProcessorMetricsRegistry
 import org.axonframework.config.EventProcessingConfiguration
 import org.axonframework.eventhandling.EventTrackerStatus
+import org.axonframework.eventhandling.Segment
 import org.axonframework.eventhandling.StreamingEventProcessor
 import org.axonframework.eventhandling.TrackingEventProcessor
 import org.axonframework.eventhandling.pooled.PooledStreamingEventProcessor
@@ -55,8 +56,9 @@ class ProcessorReportCreator(
 
     fun createSegmentOverview(processorName: String): SegmentOverview {
         val tokenStore = processingConfig.tokenStore(processorName)
+        val segments = tokenStore.fetchSegments(processorName)
         return SegmentOverview(
-            tokenStore.fetchAvailableSegments(processorName)
+            segments.map { Segment.computeSegment(it, *segments) }
                 .map { SegmentDetails(it.segmentId, it.mergeableSegmentId(), it.mask) }
         )
     }

--- a/inspector-axon/src/main/java/io/axoniq/inspector/eventprocessor/RSocketProcessorResponder.kt
+++ b/inspector-axon/src/main/java/io/axoniq/inspector/eventprocessor/RSocketProcessorResponder.kt
@@ -58,6 +58,11 @@ open class RSocketProcessorResponder(
             ResetDecision::class.java,
             this::handleReset
         )
+        registrar.registerHandlerWithPayload(
+            Routes.EventProcessor.CLAIM,
+            ProcessorSegmentId::class.java,
+            this::handleClaim
+        )
     }
 
     private fun handleStart(processorName: String) {
@@ -112,5 +117,14 @@ open class RSocketProcessorResponder(
     private fun handleReset(resetDecision: ResetDecision) {
         logger.info("Handling Inspector Axon RESET command for processor [{}]", resetDecision.processorName)
         eventProcessorManager.resetTokens(resetDecision)
+    }
+
+    fun handleClaim(processorSegmentId: ProcessorSegmentId): Boolean {
+        logger.info(
+            "Handling Inspector Axon CLAIM command for processor [{}] and segment [{}]",
+            processorSegmentId.processorName,
+            processorSegmentId.segmentId
+        )
+        return eventProcessorManager.claimSegment(processorSegmentId.processorName, processorSegmentId.segmentId)
     }
 }


### PR DESCRIPTION
This operation will always wait until the segment is claimed by the processor, up to 30 seconds. 
If the target is a PSEP, it will act actively by setting the `unclaimedSegmentValidationThreshold` of the `CoordinationTask` to `0` and scheduling it immediately. In my tests this will happen in <100ms, preventing 'downtime' of segments during scaling, merge and split operations.

Note that this branch is based on an earlier fix branch and for this reason includes two commits. 