### PR TITLE
Remove redundant logging

### DIFF
--- a/inspector-axon/src/main/java/io/axoniq/inspector/client/RSocketHandlerRegistrar.kt
+++ b/inspector-axon/src/main/java/io/axoniq/inspector/client/RSocketHandlerRegistrar.kt
@@ -69,7 +69,7 @@ class RSocketHandlerRegistrar(
         matchingHandler: PayloadlessRegisteredRsocketMessageHandler,
         route: String,
     ): Any {
-        logger.info("Received Inspector Axon message for route [$route] without payload")
+        logger.debug("Received Inspector Axon message for route [$route]")
         return matchingHandler.handler.invoke()
     }
 
@@ -79,7 +79,7 @@ class RSocketHandlerRegistrar(
         route: String,
     ): Any {
         val decodedPayload = encodingStrategy.decode(payload, matchingHandler.payloadType)
-        logger.info("Received Inspector Axon message for route [$route] with payload: [{}]", decodedPayload)
+        logger.debug("Received Inspector Axon message for route [$route] with payload: [{}]", decodedPayload)
         return matchingHandler.handler.invoke(decodedPayload)
     }
 

--- a/inspector-axon/src/main/java/io/axoniq/inspector/eventprocessor/RSocketProcessorResponder.kt
+++ b/inspector-axon/src/main/java/io/axoniq/inspector/eventprocessor/RSocketProcessorResponder.kt
@@ -76,12 +76,12 @@ open class RSocketProcessorResponder(
     }
 
     private fun handleStatusQuery(): ProcessorStatusReport {
-        logger.info("Handling Inspector Axon STATUS command")
+        logger.debug("Handling Inspector Axon STATUS query")
         return processorReportCreator.createReport()
     }
 
     private fun handleSegmentQuery(processor: String): SegmentOverview {
-        logger.info("Handling Inspector Axon SEGMENTS command")
+        logger.debug("Handling Inspector Axon SEGMENTS query for processor [{}]", processor)
         return processorReportCreator.createSegmentOverview(processor)
     }
 


### PR DESCRIPTION
Each message to the client was being logged twice, which was very verbose. In addition, with the new functionality the SEGMENTS and STATUS queries can be executed a lot.

The log statement for each message in the RSocketHandlerRegistrar has been reduced to debug, as the log messages in RSocketProcessorResponder and similar classes already log the concrete actions.
 In addition, the SEGMENTS and STATUS queries have been reduced to debug because these don't do anything to the application.